### PR TITLE
[Feat] flyway 번호 충돌 회피

### DIFF
--- a/.github/workflows/check-flyway-migration.yml
+++ b/.github/workflows/check-flyway-migration.yml
@@ -1,0 +1,80 @@
+name: Check Flyway Migration
+
+on:
+  pull_request:
+    branches: [ develop, main ]
+    paths:
+      - 'src/main/resources/db/migration/**'
+
+permissions:
+  contents: read
+
+jobs:
+  check-migration:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check naming convention (timestamp format)
+        run: |
+          MIGRATION_DIR="src/main/resources/db/migration"
+
+          # PR에서 새로 추가된 마이그레이션 파일만 체크
+          NEW_FILES=$(git diff --name-only --diff-filter=A origin/${{ github.base_ref }}...HEAD -- "$MIGRATION_DIR")
+
+          if [ -z "$NEW_FILES" ]; then
+            echo "새로 추가된 마이그레이션 파일 없음 - 건너뜁니다"
+            exit 0
+          fi
+
+          echo "새로 추가된 파일:"
+          echo "$NEW_FILES"
+          echo ""
+
+          FAILED=false
+          for FILE in $NEW_FILES; do
+            FILENAME=$(basename "$FILE")
+            # 올바른 형식: V20260223140532__설명.sql (스크립트로 생성)
+            if ! echo "$FILENAME" | grep -qE '^V[0-9]{14}__[a-zA-Z0-9_]+\.sql$'; then
+              echo "❌ 잘못된 파일명: $FILENAME"
+              echo "   파일은 스크립트로 생성해주세요: bash scripts/new-migration.sh \"설명\""
+              echo "   예시: V20260223140532__add_user_table.sql"
+              FAILED=true
+            else
+              echo "✅ $FILENAME"
+            fi
+          done
+
+          if [ "$FAILED" = true ]; then
+            exit 1
+          fi
+
+      - name: Check duplicate version numbers
+        run: |
+          MIGRATION_DIR="src/main/resources/db/migration"
+
+          # 전체 파일에서 버전 번호(__ 앞부분) 추출 후 중복 체크
+          VERSIONS=$(ls "$MIGRATION_DIR"/V*.sql 2>/dev/null \
+            | xargs -I{} basename {} \
+            | sed 's/__.*$//' \
+            | sort)
+
+          DUPLICATES=$(echo "$VERSIONS" | uniq -d)
+
+          if [ -n "$DUPLICATES" ]; then
+            echo "❌ 중복된 버전 번호 발견:"
+            echo "$DUPLICATES"
+            exit 1
+          fi
+
+          echo "✅ 중복된 버전 번호 없음"
+
+      - name: Discord 알림 (Flyway 검사 실패)
+        if: failure()
+        run: |
+          curl -s -H "Content-Type: application/json" \
+            -d "{\"embeds\":[{\"title\":\"Flyway 마이그레이션 검사 실패 ❌\",\"description\":\"**브랜치**: ${{ github.head_ref }}\\n**PR**: ${{ github.event.pull_request.title }}\\n**커밋**: ${{ github.sha }}\",\"color\":15158332}]}" \
+            ${{ secrets.DISCORD_WEBHOOK_URL }}

--- a/scripts/new-migration.sh
+++ b/scripts/new-migration.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DESC="${1:-}"
+if [ -z "$DESC" ]; then
+  echo "Usage: bash scripts/new-migration.sh \"add game genre table\""
+  exit 1
+fi
+
+# Timestamp: YYYYMMDDHHmmss (UTC)
+TS="$(date -u +%Y%m%d%H%M%S)"
+
+# slugify (spaces -> underscore, lowercase, remove weird chars)
+SLUG="$(echo "$DESC" \
+  | tr '[:upper:]' '[:lower:]' \
+  | sed -E 's/[^a-z0-9]+/_/g; s/^_+|_+$//g')"
+
+DIR="src/main/resources/db/migration"
+mkdir -p "$DIR"
+
+FILE="$DIR/V${TS}__${SLUG}.sql"
+
+cat > "$FILE" <<EOF
+-- ${DESC}
+-- created_at_utc: ${TS}
+
+EOF
+
+echo "Created: $FILE"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,3 +1,3 @@
 rootProject.name = buildString {
-        append("NBE8-10-2-Team02")
+        append("NBE8-10-3-Team02")
     }


### PR DESCRIPTION
타임스탬프 기반으로 버전 번호를 부여하고 github action으로 번호 체크하는 방식으로 회피

**flyway 흐름**
  1. DB 스키마 변경이 필요할 때 → V[숫자]__변경내용.sql 파일을 직접 작성 ex V8_변경내용.sql
  2. 앱 재시작 → Flyway가 flyway_schema_history 확인 → V8이 없으면 실행
  3. 성공하면 flyway_schema_history에 기록되어 다음 재시작 때는 건너뜀

흐름 요약
```
bash scripts/new-migration.sh "설명"
       ↓
파일 자동 생성 (타임스탬프 + 슬러그)
       ↓
SQL 내용 작성
       ↓
PR → GitHub Actions 검사 통과 → 머지
```

### 적용하는법

1. AI한테 SQL 내용만 작성해달라고 부탁
  "users 테이블에 last_login_at 컬럼 추가하는 Flyway 마이그레이션 SQL 작성해줘. 파일명은 신경쓰지 말고 SQL 내용만 줘."
2. 파일은 스크립트로 생성
`bash scripts/new-migration.sh "add last login at to users"`

3. 생성된 파일에 AI가 써준 SQL 붙여넣기
```sql
  -- add last login at to users
  -- created_at_utc: 20260223140532

  -- 여기에 SQL 작성
  [SQL]
```