### PR TITLE
[Chore] 깃헙 워크플로우 최적화, 개선

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           java-version: '21'
           distribution: 'temurin'
-          cache: true
+          cache: 'gradle'
 
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,12 +19,13 @@ jobs:
         with:
           java-version: '21'
           distribution: 'temurin'
+          cache: true
 
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
       - name: Build and Test
-        run: ./gradlew build
+        run: ./gradlew build -x detekt
 
       - name: Discord 알림 (CI 실패)
         if: failure()

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -24,14 +24,7 @@ jobs:
         with:
           java-version: '21'
           distribution: 'temurin'
-
-      - name: Cache Gradle packages
-        uses: actions/cache@v4
-        with:
-          path: ~/.gradle/caches
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle.kts') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
+          cache: true
 
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
@@ -43,41 +36,45 @@ jobs:
 
       # ktlint — generates checkstyle XML, piped to reviewdog
       - name: Run ktlint
+        id: ktlint
         run: ./gradlew ktlintCheck
         continue-on-error: true
 
       - name: reviewdog (ktlint)
-        if: github.event_name == 'pull_request'
+        if: steps.ktlint.outcome != 'skipped'
         env:
           REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           cat build/reports/ktlint/ktlintMainSourceSetCheck/ktlintMainSourceSetCheck.xml \
-            | reviewdog -f=checkstyle -name="ktlint" -reporter="github-pr-review" -level="warning"
+            | reviewdog -f=checkstyle -name="ktlint" -reporter="github-check" -level="warning" -filter-mode="added"
 
       # detekt — generates checkstyle XML, piped to reviewdog
       - name: Run detekt
+        id: detekt
         run: ./gradlew detekt
         continue-on-error: true
 
       - name: reviewdog (detekt)
-        if: github.event_name == 'pull_request'
+        if: steps.detekt.outcome != 'skipped'
         env:
           REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           cat build/reports/detekt/detekt.xml \
-            | reviewdog -f=checkstyle -name="detekt" -reporter="github-pr-review" -level="warning"
+            | reviewdog -f=checkstyle -name="detekt" -reporter="github-check" -level="warning" -filter-mode="added"
 
       # Coverage
       - name: Test
         run: ./gradlew test jacocoTestReport
 
       - name: Coverage Report
+        if: github.event_name == 'pull_request'
         uses: madrapps/jacoco-report@v1.6.1
         with:
           paths: build/reports/jacoco/test/jacocoTestReport.xml
           token: ${{ secrets.GITHUB_TOKEN }}
           min-coverage-overall: 70
           min-coverage-changed-files: 60
+          update-comment: true
 
       - name: Print quality summary to stdout (push)
         if: github.event_name == 'push' && always()
@@ -134,3 +131,95 @@ jobs:
           echo "  └──────────────┴────────────────────────┘"
           echo ""
           echo "========================================"
+
+      - name: Comment quality summary on PR
+        if: github.event_name == 'pull_request' && always()
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require('fs');
+
+            // ktlint violation count
+            let ktlintCount = 'N/A';
+            try {
+              const xml = fs.readFileSync('build/reports/ktlint/ktlintMainSourceSetCheck/ktlintMainSourceSetCheck.xml', 'utf8');
+              ktlintCount = (xml.match(/<error /g) || []).length;
+            } catch (_) {}
+
+            // detekt violation count
+            let detektCount = 'N/A';
+            try {
+              const xml = fs.readFileSync('build/reports/detekt/detekt.xml', 'utf8');
+              detektCount = (xml.match(/<error /g) || []).length;
+            } catch (_) {}
+
+            // jacoco coverage
+            let coverage = 'N/A';
+            try {
+              const xml = fs.readFileSync('build/reports/jacoco/test/jacocoTestReport.xml', 'utf8');
+              const matches = xml.match(/type="INSTRUCTION" missed="(\d+)" covered="(\d+)"/g) || [];
+              if (matches.length > 0) {
+                const last = matches[matches.length - 1];
+                const [, missed, covered] = last.match(/missed="(\d+)" covered="(\d+)"/);
+                const m = parseInt(missed), c = parseInt(covered);
+                coverage = (m + c > 0) ? Math.round(c * 100 / (m + c)) + '%' : '0%';
+              }
+            } catch (_) {}
+
+            const icon = (count, threshold = 0) =>
+              count === 'N/A' ? '⚪' : count <= threshold ? '✅' : '❌';
+            const covNum = parseInt(coverage);
+            const covIcon = !isNaN(covNum) && covNum >= 70 ? '✅' : '❌';
+
+            const marker = '<!-- code-quality-summary -->';
+            const summaryLine = `ktlint ${icon(ktlintCount)} ${ktlintCount}건 | detekt ${icon(detektCount)} ${detektCount}건 | 커버리지 ${covIcon} ${coverage}`;
+
+            const body = `${marker}
+            <details>
+            <summary>📋 Code Quality 요약 — ${summaryLine}</summary>
+
+            ### 🔍 정적 분석
+            | 도구 | 위반 건수 | 상태 |
+            |------|----------:|:----:|
+            | ktlint | ${ktlintCount}건 | ${icon(ktlintCount)} |
+            | detekt | ${detektCount}건 | ${icon(detektCount)} |
+
+            ### 🧪 테스트 커버리지
+            | 항목 | 결과 | 기준 | 상태 |
+            |------|:----:|------|:----:|
+            | 전체 커버리지 | ${coverage} | ≥ 70% | ${covIcon} |
+
+            </details>
+            `.replace(/^            /gm, '');
+
+            const { data: comments } = await github.rest.issues.listComments({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+            });
+
+            const existing = comments.find(c => c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body,
+              });
+            }
+
+      - name: Fail if quality checks have violations
+        if: steps.ktlint.outcome == 'failure' || steps.detekt.outcome == 'failure'
+        run: |
+          echo "Code quality checks failed:"
+          [ "${{ steps.ktlint.outcome }}" = "failure" ] && echo "  - ktlint reported violations"
+          [ "${{ steps.detekt.outcome }}" = "failure" ] && echo "  - detekt reported violations"
+          exit 1

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           java-version: '21'
           distribution: 'temurin'
-          cache: true
+          cache: 'gradle'
 
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew

--- a/.github/workflows/migration-metrics.yml
+++ b/.github/workflows/migration-metrics.yml
@@ -156,6 +156,9 @@ jobs:
             const marker = '<!-- kotlin-migration-metrics -->';
 
             const body = `${marker}
+            <details>
+            <summary>📊 Kotlin 마이그레이션 메트릭 — ${progress}% 완료</summary>
+
             ## 📊 Kotlin 마이그레이션 메트릭
 
             ### 🚀 진행률: ${progress}%
@@ -202,6 +205,7 @@ jobs:
             - DTO에는 \`data class\` 사용하기
             - Builder 패턴 대신 named parameter 사용하기
             - 유틸리티 클래스 대신 확장 함수 사용하기
+            </details>
             `.replace(/^            /gm, '');
 
             const { data: comments } = await github.rest.issues.listComments({


### PR DESCRIPTION
<!--
  템플릿은 아직 PR 작성이 익숙하지 않으신 분들을 위해서 제공하는 가이드입니다!
  리뷰어 또는 이 PR을 보게 될 다른 사람들이 이 PR을 보는데 참고할 수 있는 내용이 있다면 포함해서 작성해주시면 됩니다.
-->

## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
- CI 빌드가 detekt 위반으로 실패하는 문제 해결
-  PR 코멘트가 무더기로 달리는 문제 해결 (이제 detekt, ktlint 위반사항은 코멘트 PR의 Files Changed 탭에서 볼 수 있음)
- gradle build에 캐싱 도입 
- 전체적으로 코멘트와 코드 품질 보고 워크플로우가 더 보기 편하고, 과도하지 않게 개선함

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
  ### ci.yml에서
   ***`build -x detekt` 적용**
  - `./gradlew build`가 detekt를  `-x detekt`로 detekt를 CI 빌드에서 제외 → detekt, ktlint와 무관하게 빌드·테스트는 항상 실행

  **reviewdog reporter `github-pr-review` → `github-check` 변경**
  - 기존 `github-pr-review`는 위반 1개마다 개별 PR 댓글을 생성 → 100건 이상 시 코멘트 범람
  - 초과분은 "Remaining comments…" 로 숨겨지는데 이건 수정 후에도 삭제되지 않는 문제 존재
  - `github-check`로 변경 시 Files Changed 탭의 어노테이션으로 표시, 자동 갱신
  **reviewdog `filter-mode` `nofilter` → `added`로 변경**
  - 전체 코드베이스 위반 대신 이번 PR에서 추가/수정된 줄의 위반만 어노테이션으로 표시
  - 기여자가 본인 코드의 문제만 알게 됨.
  
  **PR 품질 요약 코멘트 추가 (딱 1개씩만 달리도록)**
  - ktlint·detekt 위반 건수, 전체 커버리지를 접힌 형태로 코멘트. create-or-update로 매 푸시마다 1개만 유지
  - `madrapps/jacoco-report`에 `update-comment: true` 추가
    
### code-quality.yml에서
-  PR 코멘트 `<details>`로 접기 (보기 편하라고)
  **code-quality job 실패 조건 추가**
  - ktlint·detekt에 `continue-on-error: true`만 있어 위반이 있어도 잡이 성공으로 표시되었음. -> 이제 ci는 ktlint·detekt 위반 시에도 무조건 성공, 대신 code-quality 잡은 빡빡하게 잡아서 위반 있을시 실패하게 함

### migration-metrics.yml에서
-  PR 코멘트 `<details>`로 접기  (보기 편하라고)

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
