### PR TITLE
[Fix] flyway action 버그수정

### DIFF
--- a/.github/workflows/check-flyway-migration.yml
+++ b/.github/workflows/check-flyway-migration.yml
@@ -3,8 +3,6 @@ name: Check Flyway Migration
 on:
   pull_request:
     branches: [ develop, main ]
-    paths:
-      - 'src/main/resources/db/migration/**'
 
 permissions:
   contents: read
@@ -18,7 +16,20 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Check if migration files changed
+        id: check_files
+        run: |
+          MIGRATION_DIR="src/main/resources/db/migration"
+          CHANGED=$(git diff --name-only origin/${{ github.base_ref }}...HEAD -- "$MIGRATION_DIR")
+          if [ -z "$CHANGED" ]; then
+            echo "마이그레이션 파일 변경 없음 - 검사를 건너뜁니다"
+            echo "skip=true" >> $GITHUB_OUTPUT
+          else
+            echo "skip=false" >> $GITHUB_OUTPUT
+          fi
+
       - name: Check naming convention (timestamp format)
+        if: steps.check_files.outputs.skip != 'true'
         run: |
           MIGRATION_DIR="src/main/resources/db/migration"
 
@@ -53,6 +64,7 @@ jobs:
           fi
 
       - name: Check duplicate version numbers
+        if: steps.check_files.outputs.skip != 'true'
         run: |
           MIGRATION_DIR="src/main/resources/db/migration"
 


### PR DESCRIPTION
### 문제 원인
**paths 필터 + Required Status Check 충돌**

check-flyway-migration.yml의 트리거를 보면
```yml
on:
  pull_request:
    branches: [ develop, main ]
    paths:
      - 'src/main/resources/db/migration/**'
```
paths 필터가 있어서 마이그레이션 파일이 변경된 PR에서만 워크플로우가 실행

그런데 GitHub 브랜치 보호 규칙에 check-migration이 Required Status Check로 등록되어 있으면

1. PR에서 마이그레이션 파일이 없음 → 워크플로우 아예 실행 안 됨
2. GitHub은 해당 status가 보고되길 기다림 → Expected — Waiting for status to be reported 무한 대기

워크플로우가 실행되지 않으면 status 자체가 GitHub에 전달되지 않아서 required check를 통과할 수 없는 상태가 된다.

### 해결 방법

1. paths 필터 제거
모든 PR에서 워크플로우가 실행되어 status를 항상 GitHub에 보고
2. Check if migration files changed step 추가
마이그레이션 파일 변경 여부를 job 내부에서 판단하고 skip output을 설정
3. 기존 두 검사 step에 `if: steps.check_files.outputs.skip != 'true'` 조건 추가
마이그레이션 파일이 없는 PR에서는 실제 검사를 건너뜀
